### PR TITLE
merge Preview text

### DIFF
--- a/bot/util.go
+++ b/bot/util.go
@@ -13,18 +13,15 @@ func trimDescription(desc string, limit int) string {
 		return ""
 	}
 	desc = strings.Trim(
-		strip.StripTags(
-			regexp.MustCompile("\n+").ReplaceAllLiteralString(
-				strings.ReplaceAll(
-					regexp.MustCompile(`<br(| /)>`).ReplaceAllString(
-						html.UnescapeString(desc), "<br>"),
-					"<br>", "\n"),
-				"\n")),
-		"\n")
+		regexp.MustCompile("[\t\f\r ]+").ReplaceAllString(
+			strip.StripTags(regexp.MustCompile("< *br */* *>").ReplaceAllString(html.UnescapeString(desc), "\n")),
+			" "),
+		"\n ")
 
 	contentDescRune := []rune(desc)
 	descLen := len(contentDescRune)
-	// in latin alphabets, len(str) == len([]rune)
+	// 在拉丁字母中，len(str) == len([]rune)
+	// 在这里将拉丁字母长度计 0.5（在这里乘2）
 	if len(desc) == descLen {
 		descLen /= 2
 		limit *= 2

--- a/bot/util.go
+++ b/bot/util.go
@@ -23,7 +23,13 @@ func trimDescription(desc string, limit int) string {
 		"\n")
 
 	contentDescRune := []rune(desc)
-	if len(contentDescRune) > limit {
+	descLen := len(contentDescRune)
+	// in latin alphabets, len(str) == len([]rune)
+	if len(desc) == descLen {
+		descLen /= 2
+		limit *= 2
+	}
+	if descLen > limit {
 		desc = string(contentDescRune[:limit])
 	}
 


### PR DESCRIPTION
修改预览中的正则表达式，可以应对多余空格
修改长度判断逻辑，当预览内容均为拉丁字母，总体长度计为实际长度一半