### PR TITLE
merge "MergeMessage"

### DIFF
--- a/config.yml.sample
+++ b/config.yml.sample
@@ -27,3 +27,25 @@ sqlite:
   path: ./data.db
 
 allowed_users:
+
+merge_message:
+  enable: true
+  item_tpl: |
+    {{if .EnableTelegraph}}
+    [{{.ContentTitle}}]({{.TelegraphURL}}) - [原文]({{.RawLink}})
+    {{- else }}
+    [{{.ContentTitle}}]({{.RawLink}})
+    {{- end }}
+
+message_mode: md
+message_tpl: |
+    ** {{.SourceTitle}} **{{ if .PreviewText }}
+    ---------- Preview ----------
+    {{.PreviewText}}
+    -----------------------------
+    {{- end}}{{if .EnableTelegraph}}
+    {{.ContentTitle}} [Telegraph]({{.TelegraphURL}}) | [原文]({{.RawLink}})
+    {{- else }}
+    [{{.ContentTitle}}]({{.RawLink}})
+    {{- end }}
+    {{.Tags}}

--- a/config/config.go
+++ b/config/config.go
@@ -58,6 +58,15 @@ var (
 
 	// DBLogMode 是否打印数据库日志
 	DBLogMode bool = false
+
+	// 当 feed 有多个条目更新时，是否合并为一条消息
+	MergeMessage bool = false
+
+	// 使用列表发送消息时的心消息阈值
+	MergeTolerance int = 2
+
+	// 合并消息中单条消息模板，模式与 MessageMode 一致
+	MessageItemTpl *template.Template
 )
 
 const (
@@ -92,8 +101,9 @@ const (
 {{- end }}
 {{.Tags}}
 `
-	TestMode    RunType = "Test"
-	ReleaseMode RunType = "Release"
+	defaultMessageListItemTpl         = `[{{.ContentTitle}}]({{.TelegraphURL}})`
+	TestMode                  RunType = "Test"
+	ReleaseMode               RunType = "Release"
 )
 
 // MysqlConfig mysql 配置
@@ -113,6 +123,7 @@ type TplData struct {
 	TelegraphURL    string
 	Tags            string
 	EnableTelegraph bool
+	IsItem          bool
 }
 
 func AppVersionInfo() (s string) {

--- a/config/config.go
+++ b/config/config.go
@@ -101,9 +101,11 @@ const (
 {{- end }}
 {{.Tags}}
 `
-	defaultMessageListItemTpl         = `[{{.ContentTitle}}]({{.TelegraphURL}})`
-	TestMode                  RunType = "Test"
-	ReleaseMode               RunType = "Release"
+	defaultMessageListItemTpl = `{{if .EnableTelegraph}}
+[{{.ContentTitle}}]({{.TelegraphURL}}) - [原文]({{.RawLink}}){{- else }}
+[{{.ContentTitle}}]({{.RawLink}}){{- end }}`
+	TestMode    RunType = "Test"
+	ReleaseMode RunType = "Release"
 )
 
 // MysqlConfig mysql 配置


### PR DESCRIPTION
增加合并消息功能
当单个订阅源更新消息数量多余阈值（MergeTolerance，默认为2），会将改订阅源所有新内容合并到一条消息中。
消息合并通过“merge_message.enable”配置
单条消息展示格式通过“message_item.item_tpl”配置，配置内容与“message_tpl”相同，模式与“message_mode”同步。

配置样例：
```
merge_message:
  enable: true
  item_tpl: >
    {{if .EnableTelegraph}}
    [{{.ContentTitle}}]({{.TelegraphURL}}) - [原文]({{.RawLink}})
    {{- else }}
    [{{.ContentTitle}}]({{.RawLink}})
    {{- end }}
```
